### PR TITLE
Small bug fixing

### DIFF
--- a/website/src/components/TutorialComponents/index.tsx
+++ b/website/src/components/TutorialComponents/index.tsx
@@ -154,12 +154,6 @@ export default function CustomCodeBlock({ input }) {
           } else if (result.error) {
             newResult.error = result.error;
             newResult.status = statusCodes.runError;
-          } else {
-            // both output and error are empty, which means we have a bug
-            errorMsg = `${lang}-web returned no output or error with input:\n${currCode}`;
-            newResult.error = errorMsg;
-            newResult.status = "buggy-code";
-            throw new Error(errorMsg);
           }
         })
         .catch((error) => {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -13,8 +13,8 @@ function HomepageHeader() {
   return (
     <div className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
-        <div class="row" >
-          <div class="col format">
+        <div className="row" >
+          <div className="col format">
             <h1 className="hero__title">{siteConfig.title}</h1>
             <p className="hero__subtitle">{siteConfig.tagline}</p>
             <div className={styles.buttons}>
@@ -37,7 +37,7 @@ function HomepageHeader() {
             </Link>
             </div>
           </div>
-          <div class="col">
+          <div className="col">
             {/* <img src="/img/logoz3.png" alt="Z3 Logo"></img> */}
             <img src={require('@site/static/img/logoz3.png').default} />
           </div>

--- a/website/src/remark/render-code-blocks.mjs
+++ b/website/src/remark/render-code-blocks.mjs
@@ -186,7 +186,7 @@ export default function plugin() {
                     // so just add the syntax highlighting and github discussion button (if configured)
 
                     if (githubRepo) {
-                        const input = JSON.stringify({repo: langConfig.githubRepo});
+                        const input = JSON.stringify(githubRepo);
                         parent.children.splice(
                             index,
                             1,


### PR DESCRIPTION
Fix:
- #84 
- #77 

In addition, for React components the `class` attribute of DOM elements should be `className` instead (not causing errors but warnings. Eslint should report such errors to you through highlighting).
@ayanamonr