### PR TITLE
Add missing free variable in Guess the Secret Formula

### DIFF
--- a/website/docs-playground/02 - Guess the Secret Formula.md
+++ b/website/docs-playground/02 - Guess the Secret Formula.md
@@ -93,6 +93,7 @@ counter-examples.
 
 ```z3-duo
 (declare-const x (_ BitVec 32))
+(declare-const y (_ BitVec 32))
 ------
 
 ; count number of 1's in a bit-vector


### PR DESCRIPTION
Noticed the y variable showing up while solving this, even though it only listed x.