### PR TITLE
Fix typo on Python Application Install Problem

### DIFF
--- a/website/docs-programming/02 - Z3 Python - Readonly/01 - Introduction.md
+++ b/website/docs-programming/02 - Z3 Python - Readonly/01 - Introduction.md
@@ -871,7 +871,7 @@ def DependsOn(pack, deps):
 ```
 
 
-Thus, `Depends(a, [b, c, z])` generates the constraint
+Thus, `DependsOn(a, [b, c, z])` generates the constraint
 
 
 ```


### PR DESCRIPTION
Typo on the python docs — `Depends` &rarr; `DependsOn` per the function declaration a few lines before.