### PR TITLE
Fixed remaining py2-only print

### DIFF
--- a/website/docs-programming/02 - Z3 Python - Readonly/01 - Introduction.md
+++ b/website/docs-programming/02 - Z3 Python - Readonly/01 - Introduction.md
@@ -114,7 +114,7 @@ y = Real('y')
 solve(x**2 + y**2 == 3, x**3 == 2)
 
 set_option(precision=30)
-print "Solving, and displaying result with 30 decimal places"
+print ("Solving, and displaying result with 30 decimal places")
 solve(x**2 + y**2 == 3, x**3 == 2)
 ```
 
@@ -131,9 +131,9 @@ Z3 rational where `num` is the numerator and `den` is the denominator. The `Real
 representing the number `1`.
 
 ```z3-python
-print 1/3
-print RealVal(1)/3
-print Q(1,3)
+print (1/3)
+print (RealVal(1)/3)
+print (Q(1,3))
 
 x = Real('x')
 print (x + 1/3)
@@ -219,7 +219,7 @@ x = Int('x')
 y = Int('y')
 
 s = Solver()
-print s
+print (s)
 
 s.add(x > 10, y == x + 2)
 print (s)
@@ -354,10 +354,10 @@ The command `simplify` applies simple transformations on Z3 expressions.
 x, y = Reals('x y')
 # Put expression in sum-of-monomials form
 t = simplify((x + y)**3, som=True)
-print t
+print (t)
 # Use power operator
 t = simplify(t, mul_to_power=True)
-print t
+print (t)
 ```
 
 The command `help_simplify()` prints all available options.

--- a/website/docs-programming/02 - Z3 Python - Readonly/02 - advanced.md
+++ b/website/docs-programming/02 - Z3 Python - Readonly/02 - advanced.md
@@ -90,7 +90,7 @@ print ("\n")
 # f is a function from (Int, Real) to Bool
 f   = Function('f', IntSort(), RealSort(), BoolSort())
 print ("f.name():         ", f.name())
-print "f.range():        ", f.range()
+print ("f.range():        ", f.range())
 print ("f.arity():        ", f.arity())
 for i in range(f.arity()):
     print ("domain(", i, "): ", f.domain(i))
@@ -271,7 +271,7 @@ List.declare('cons', ('car', IntSort()), ('cdr', List))
 List.declare('nil')
 # Create the datatype
 List = List.create()
-print is_sort(List)
+print (is_sort(List))
 cons = List.cons
 car  = List.car
 cdr  = List.cdr
@@ -741,14 +741,14 @@ s.add(Implies(p1, x > 10),
       Implies(p1, y > x),
       Implies(p2, y < 5),
       Implies(p3, y > 0))
-print s
+print (s)
 # Check satisfiability assuming p1, p2, p3 are true
 print (s.check(p1, p2, p3))
 print (s.unsat_core())
 
 # Try again retracting p2
-print s.check(p1, p3)
-print s.model()
+print (s.check(p1, p3))
+print (s.model())
 ```
 
 The example above also shows that a Boolean variable (<tt>p1</tt>) can be used to track


### PR DESCRIPTION
Some of print usage is not python-3 compatible. Since py2 is end-of-life for quite some time, convert the remaining py2-only usage of print. 