### PR TITLE
docs-smtlib: Update links to smtlib documentation

### DIFF
--- a/website/docs-smtlib/01 - logic/01 - intro.md
+++ b/website/docs-smtlib/01 - logic/01 - intro.md
@@ -22,7 +22,7 @@ Z3 is a low-level tool. It is best used as a component in the context of other t
 
 ## SMTLIB Format
 
-> This tutorial uses Z3's frontend for the [SMTLIB format](http://smtlib.cs.uiowa.edu/).
+> This tutorial uses Z3's frontend for the [SMTLIB format](https://smt-lib.org/).
 
 The SMTLIB format is a community standard used by several SMT solvers. 
 It uses LISP-like syntax to make it easy for tools to serialize and de-serialize models. 

--- a/website/docs-smtlib/01 - logic/07 - Recursive Functions.md
+++ b/website/docs-smtlib/01 - logic/07 - Recursive Functions.md
@@ -4,7 +4,7 @@ sidebar_position: 7
 ---
 
 
->  **SMTLIB2** standard: [Page 62](http://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2021-05-12.pdf)
+>  **SMTLIB2** standard: [Page 62](https://smt-lib.org/papers/smt-lib-reference-v2.6-r2021-05-12.pdf)
 
 
 You can define recursive functions

--- a/website/docs-smtlib/02 - theories/01 - Arithmetic.md
+++ b/website/docs-smtlib/02 - theories/01 - Arithmetic.md
@@ -7,11 +7,11 @@ sidebar_position: 1
 
 Z3 supports the theory of arithmetic described in the following places.
 
->  [**SMTLIB2** standard Integers](http://smtlib.cs.uiowa.edu/theories-Ints.shtml)
+>  [**SMTLIB2** standard Integers](https://smt-lib.org/theories-Ints.shtml)
 
->  [**SMTLIB2** standard Reals](http://smtlib.cs.uiowa.edu/theories-Reals.shtml)
+>  [**SMTLIB2** standard Reals](https://smt-lib.org/theories-Reals.shtml)
 
->  [**SMTLIB2** standard Mixed Int Reals](http://smtlib.cs.uiowa.edu/theories-Reals_Ints.shtml)
+>  [**SMTLIB2** standard Mixed Int Reals](https://smt-lib.org/theories-Reals_Ints.shtml)
 
 :::
 

--- a/website/docs-smtlib/02 - theories/02 - Bitvectors.md
+++ b/website/docs-smtlib/02 - theories/02 - Bitvectors.md
@@ -3,7 +3,7 @@ title: Bitvectors
 sidebar_position: 2
 ---
 
->  **SMTLIB2** standard [The Theory of fixed sized bit-vectors](http://smtlib.cs.uiowa.edu/theories-FixedSizeBitVectors.shtml)
+>  **SMTLIB2** standard [The Theory of fixed sized bit-vectors](https://smt-lib.org/theories-FixedSizeBitVectors.shtml)
 
 Modern CPUs and main-stream programming languages use arithmetic over fixed-size bit-vectors. The theory of bit-vectors allows modeling the precise semantics of unsigned and of signed two-complements arithmetic. There are a large number of supported functions and relations over bit-vectors. They are summarized on Z3's documentation [link](https://z3prover.github.io/api/html/z3__api_8h.html). We will not try to give a comprehensive overview here, but touch on some of the main features.
 

--- a/website/docs-smtlib/02 - theories/03 - IEEE Floats.md
+++ b/website/docs-smtlib/02 - theories/03 - IEEE Floats.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 ---
 
 
-> **SMTLIB2 standard** [IEEE Floating Point Numbers](http://smtlib.cs.uiowa.edu/theories-FloatingPoint.shtml)
+> **SMTLIB2 standard** [IEEE Floating Point Numbers](https://smt-lib.org/theories-FloatingPoint.shtml)
 
 
 

--- a/website/docs-smtlib/02 - theories/04 - Arrays.md
+++ b/website/docs-smtlib/02 - theories/04 - Arrays.md
@@ -3,7 +3,7 @@ title: Arrays
 sidebar_position: 4
 ---
 
-> **SMTLIB2 standard** [Arrays](http://smtlib.cs.uiowa.edu/theories-ArraysEx.shtml)
+> **SMTLIB2 standard** [Arrays](https://smt-lib.org/theories-ArraysEx.shtml)
 
 
 As part of formulating a programme of a mathematical theory of computation McCarthy proposed a _basic_ theory of arrays as characterized by the select-store axioms. The expression (select a i) returns the value stored at position i of the array a; and (store a i v) returns a new array identical to a, but on position i it contains the value v.

--- a/website/docs-smtlib/02 - theories/06 - Strings.md
+++ b/website/docs-smtlib/02 - theories/06 - Strings.md
@@ -3,7 +3,7 @@ title: Strings
 sidebar_position: 6
 ---
 
-> **SMTLIB2 standard** [The theory of unicode strings](http://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml)
+> **SMTLIB2 standard** [The theory of unicode strings](https://smt-lib.org/theories-UnicodeStrings.shtml)
 
 ## Introduction
 
@@ -22,7 +22,7 @@ heuristic solver
 and the full combination of lengths and sequences 
 (and regular expressions) is not decidable anyway.
 In Z3, strings are a special case of sequences, and for the case of Unicode strings,
-and regular expressions over Unicode strings seeks to implement the [SMTLIB2 standard](http://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml).
+and regular expressions over Unicode strings seeks to implement the [SMTLIB2 standard](https://smt-lib.org/theories-UnicodeStrings.shtml).
 
 You can configure z3 to use one of two backends for solving strings.
 The default backend is called the `seq` solver. It solves constraints over both sequences and strings.

--- a/website/docs-smtlib/02 - theories/08 - Regular Expressions.md
+++ b/website/docs-smtlib/02 - theories/08 - Regular Expressions.md
@@ -4,12 +4,12 @@ sidebar_position: 8
 ---
 
 
-> **SMTLIB2 standard** [The theory of unicode strings and regular expressions](http://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml)
+> **SMTLIB2 standard** [The theory of unicode strings and regular expressions](https://smt-lib.org/theories-UnicodeStrings.shtml)
 
 
 The sort constructor `RegEx` takes as argument a sequence type.
 The set of regular expressions over strings is thus `(RegEx String)`; 
-it is synonymous with the sort `RegLan` defined in the [SMTLIB2 format](http://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml).
+it is synonymous with the sort `RegLan` defined in the [SMTLIB2 format](https://smt-lib.org/theories-UnicodeStrings.shtml).
 
 # Summary of Operations
 

--- a/website/docs-smtlib/04 - optimization/03 - arithmeticaloptimization.md
+++ b/website/docs-smtlib/04 - optimization/03 - arithmeticaloptimization.md
@@ -3,7 +3,7 @@ title: Arithmetical Optimization
 sidebar_position: 3
 ---
 
-Z3 extends the The [SMTLIB format](http://smtlib.cs.uiowa.edu/) with the following commands for working with optimization objectives:
+Z3 extends the The [SMTLIB format](https://smt-lib.org/) with the following commands for working with optimization objectives:
 
 Command                                | Meaning
 ---------------------------------------|-------------------------------------------------------------------


### PR DESCRIPTION
The home and documentatin of smtlib has moved.
Replace http://smtlib.cs.uiowa.edu/ with https://smt-lib.org/