### PR TITLE
Update domain for "SAT/SMT by Example"

### DIFF
--- a/website/docs-smtlib/01 - logic/01 - intro.md
+++ b/website/docs-smtlib/01 - logic/01 - intro.md
@@ -14,7 +14,7 @@ The main objective of the tutorial is to introduce the reader on how to use Z3 e
 
  > For an understanding of decision procedures, algorithms that, given a decision problem, terminate with a correct yes or no answer, refer to [Decision Procedures by Daniel Kroening and Ofer Strichman](http://www.decision-procedures.org/)
  
- > For an overview of Satisfiability modulo theories (SMT) and Boolean satisfiability problem (SAT) solvers, examples of their theoretical application, and questions to work through, refer to [SAT/SMT by Example by Dennis Yurichev](https://sat-smt.codes/SAT_SMT_by_example.pdf) 
+ > For an overview of Satisfiability modulo theories (SMT) and Boolean satisfiability problem (SAT) solvers, examples of their theoretical application, and questions to work through, refer to [SAT/SMT by Example by Dennis Yurichev](https://smt.st/SAT_SMT_by_example.pdf) 
 
 :::
 


### PR DESCRIPTION
Change domain from [sat-smt.codes](https://sat-smt.codes) into [smt.st](https://smt.st) because the old one will be defunct in September 2024

![image](https://github.com/user-attachments/assets/d61652dd-6696-46ca-a59a-edf7ede00974)
