### PR TITLE
Added missing operations of division on Bitvectors

### DIFF
--- a/website/docs-smtlib/02 - theories/02 - Bitvectors.md
+++ b/website/docs-smtlib/02 - theories/02 - Bitvectors.md
@@ -29,6 +29,8 @@ Z3 supports Bitvectors of arbitrary size. (\_ BitVec n) is the sort of bitvector
 (simplify (bvsub #x07 #x03)) ; subtraction
 (simplify (bvneg #x07)) ; unary minus
 (simplify (bvmul #x07 #x03)) ; multiplication
+(simplify (bvudiv #x07 #x03)) ; unsigned division
+(simplify (bvsdiv #x07 #x03)) ; signed division
 (simplify (bvurem #x07 #x03)) ; unsigned remainder
 (simplify (bvsrem #x07 #x03)) ; signed remainder
 (simplify (bvsmod #x07 #x03)) ; signed modulo


### PR DESCRIPTION
I couldn't find any reference to the bitvector division operators.
Through trial and error I discovered bvsdiv, as I knew of bvudiv.
A simple accessible documentation on the web would be nice.